### PR TITLE
Fix build fonts and improve theme responsiveness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,17 +15,20 @@
 
 .dark {
   --background: #0f172a;
-  --foreground: #f1f5f9;
+  /* Slightly reduce foreground brightness for more comfortable reading */
+  --foreground: #e2e8f0;
   --surface: #1e293b;
-  --surface-dark: #334155;
-  --border: #334155;
-  --border-light: #475569;
+  /* Lighten dark surfaces and borders to improve contrast */
+  --surface-dark: #2b3748;
+  --border: #475569;
+  --border-light: #64748b;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  /* Use system fonts to avoid external font dependencies */
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   transition: background-color 0.3s ease, color 0.3s ease;
   line-height: 1.6;
   min-height: 100vh;
@@ -33,6 +36,13 @@ body {
   overflow-x: hidden;
   /* Enable momentum scrolling on iOS */
   -webkit-overflow-scrolling: touch;
+}
+
+/* Slightly adjust base font size on very small screens for better fit */
+@media (max-width: 360px) {
+  body {
+    font-size: 0.95rem;
+  }
 }
 
 /* Music Player Enhancements */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,17 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navigation from "@/components/Navigation";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
 export const metadata: Metadata = {
   title: "TrackerParse",
   description: "Music tracker for artist discographies",
+};
+
+// Improve mobile scaling by explicitly defining viewport properties
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -27,6 +22,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -57,9 +53,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gradient-to-br from-white via-slate-50 to-blue-50 dark:from-slate-900 dark:via-blue-900 dark:to-indigo-900 text-gray-900 dark:text-white transition-all duration-300`}
-      >
+      <body className="antialiased min-h-screen bg-gradient-to-br from-white via-slate-50 to-blue-50 dark:from-slate-900 dark:via-blue-900 dark:to-indigo-900 text-gray-900 dark:text-white transition-all duration-300">
         <ThemeProvider>
           <Navigation />
           <main className="pt-16 pb-24 min-h-[calc(100vh-4rem)] px-2 sm:px-4">


### PR DESCRIPTION
## Summary
- remove Google font imports and use system fonts to avoid build-time network failures
- add mobile viewport, dark-theme contrast tweaks and small-screen font scaling

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68902f7abc908329b872658823f9c594