### PR TITLE
Fix mobile player and track detail layout

### DIFF
--- a/src/app/[spreadsheetId]/page.tsx
+++ b/src/app/[spreadsheetId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { ParsedSpreadsheetData, Track } from "@/types";
 import Artist from "@/components/Artist";
 import MusicPlayer from "@/components/MusicPlayer";
+import TrackDetailPage from "@/components/TrackDetailPage";
 import SheetNavigation, { SheetType } from "@/components/SheetNavigation";
 
 export default function SpreadsheetPage() {
@@ -17,6 +18,7 @@ export default function SpreadsheetPage() {
   const [error, setError] = useState<string | null>(null);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const [isMusicPlayerVisible, setIsMusicPlayerVisible] = useState(false);
+  const [infoTrack, setInfoTrack] = useState<Track | null>(null);
   const [currentSheet, setCurrentSheet] = useState<SheetType>('unreleased');
   const [sheetLoading, setSheetLoading] = useState(false);
 
@@ -95,6 +97,13 @@ export default function SpreadsheetPage() {
     setCurrentTrack(null);
   };
 
+  const handleTrackInfo = (track: Track) => {
+    setInfoTrack(track);
+  };
+  const handleCloseInfo = () => {
+    setInfoTrack(null);
+  };
+
   if (loading || sheetLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
@@ -141,8 +150,8 @@ export default function SpreadsheetPage() {
         onSheetChange={handleSheetChange}
         isLoading={sheetLoading}
       />
-      <Artist 
-        artist={data.artist} 
+      <Artist
+        artist={data.artist}
         onPlayTrack={handlePlayTrack}
         docId={spreadsheetId}
         sourceUrl={`https://docs.google.com/spreadsheets/d/${spreadsheetId}`}
@@ -152,7 +161,15 @@ export default function SpreadsheetPage() {
         track={currentTrack}
         isVisible={isMusicPlayerVisible}
         onClose={handleCloseMusicPlayer}
+        onInfo={handleTrackInfo}
       />
+      {infoTrack && (
+        <TrackDetailPage
+          track={infoTrack}
+          onClose={handleCloseInfo}
+          onPlay={handlePlayTrack}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Artist.tsx
+++ b/src/components/Artist.tsx
@@ -251,7 +251,7 @@ export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetTyp
 
   const totalFilteredTracks = filteredAlbums.reduce((total, album) => total + album.tracks.length, 0);
   return (
-    <div className="max-w-6xl mx-auto p-3 sm:p-6">
+    <div className="w-full px-2 sm:px-6 py-3 sm:py-6">
       {/* Artist Header - Reduced spacing */}
       <div className="text-center mb-4 sm:mb-6">
         <h1 className="text-3xl sm:text-4xl font-bold text-gray-800 dark:text-white mb-2">

--- a/src/components/CollapsedTrack.tsx
+++ b/src/components/CollapsedTrack.tsx
@@ -403,7 +403,7 @@ export default function CollapsedTrack({ tracks, onPlay, onScrollToTrack }: Coll
 
       {/* Inline Versions View */}
       {showVersionsView && tracks.length > 1 && (
-        <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-750">
+        <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
           <div className="p-3">
             <div className="space-y-2">
               {tracks.map((track, index) => {

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -8,9 +8,10 @@ interface MusicPlayerProps {
   track: Track | null;
   isVisible: boolean;
   onClose: () => void;
+  onInfo?: (track: Track) => void;
 }
 
-export default function MusicPlayer({ track, isVisible, onClose }: MusicPlayerProps) {
+export default function MusicPlayer({ track, isVisible, onClose, onInfo }: MusicPlayerProps) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
@@ -197,7 +198,7 @@ export default function MusicPlayer({ track, isVisible, onClose }: MusicPlayerPr
       <div className="max-w-7xl mx-auto px-3 sm:px-4 py-2 sm:py-4">
         <div className="flex flex-col space-y-2 sm:space-y-3">
           {/* Track Info and Controls Row */}
-          <div className="grid grid-cols-3 items-center gap-2">
+          <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2">
             {/* Track Info - Left */}
             <div className="flex items-center space-x-2 sm:space-x-3 min-w-0">
               <div className="w-10 h-10 sm:w-14 sm:h-14 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -213,7 +214,22 @@ export default function MusicPlayer({ track, isVisible, onClose }: MusicPlayerPr
                   {track.era}
                 </p>
               </div>
-              {/* Metadata Button - Mobile */}
+              {onInfo && (
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onInfo(track);
+                  }}
+                  className="p-1.5 sm:p-2.5 text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400 transition-colors rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 active:scale-95 flex-shrink-0"
+                  title="Track info"
+                  aria-label="View track info"
+                >
+                  <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 18a6 6 0 100-12 6 6 0 000 12z" />
+                  </svg>
+                </button>
+              )}
               {isPillowcase && playable?.id && (
                 <button
                   onClick={(e) => {
@@ -233,7 +249,7 @@ export default function MusicPlayer({ track, isVisible, onClose }: MusicPlayerPr
             </div>
 
             {/* Player Controls - Center */}
-            <div className="flex items-center justify-center space-x-2 sm:space-x-4">
+            <div className="flex items-center justify-center space-x-2 sm:space-x-4 justify-self-center">
               {(audioUrl && !isSoundCloudLink && !isYouTubeLink) || (youtubeAudioUrl) ? (
                 <button
                   onClick={togglePlayPause}
@@ -301,7 +317,7 @@ export default function MusicPlayer({ track, isVisible, onClose }: MusicPlayerPr
             </div>
 
             {/* Volume Control - Right (Hidden on mobile) */}
-            <div className="flex justify-end">
+            <div className="flex justify-end justify-self-end">
               {((audioUrl && !isSoundCloudLink && !isYouTubeLink) || youtubeAudioUrl) && (
                 <div className="hidden sm:flex items-center space-x-2 w-32">
                   <svg className="w-4 h-4 text-gray-600 dark:text-gray-300 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">

--- a/src/components/SheetNavigation.tsx
+++ b/src/components/SheetNavigation.tsx
@@ -46,11 +46,11 @@ export default function SheetNavigation({ currentSheet, onSheetChange, isLoading
               disabled={isLoading}
               className={`
                 flex items-center space-x-2 px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 whitespace-nowrap
-                ${currentSheet === sheet.id 
-                  ? `${sheet.color} text-white shadow-md` 
+                ${currentSheet === sheet.id
+                  ? `${sheet.color} text-white shadow-md`
                   : 'bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300'
                 }
-                ${isLoading ? 'opacity-50 cursor-not-allowed' : 'hover:scale-105'}
+                ${isLoading ? 'opacity-50 cursor-not-allowed' : 'hover:scale-105'} flex-shrink-0
               `}
               title={sheet.description}
             >

--- a/src/components/TrackDetailPage.tsx
+++ b/src/components/TrackDetailPage.tsx
@@ -113,9 +113,8 @@ export default function TrackDetailPage({ track, onClose, onPlay }: TrackDetailP
   };
 
   return (
-    <div 
-      className="fixed inset-0 bg-black bg-opacity-80 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4" 
-      style={{ zIndex: 50000 }}
+    <div
+      className="fixed inset-0 bg-black/80 backdrop-blur-sm overflow-y-auto p-2 sm:p-4 z-50 flex justify-center items-start"
       onClick={(e) => {
         // Close when clicking the backdrop
         if (e.target === e.currentTarget) {
@@ -123,8 +122,8 @@ export default function TrackDetailPage({ track, onClose, onPlay }: TrackDetailP
         }
       }}
     >
-      <div 
-        className="bg-white dark:bg-gray-900 rounded-xl w-full max-w-xs sm:max-w-4xl max-h-[95vh] sm:max-h-[90vh] overflow-hidden shadow-2xl border border-gray-200 dark:border-gray-600"
+      <div
+        className="bg-white dark:bg-gray-900 rounded-xl w-full max-w-xs sm:max-w-4xl shadow-2xl border border-gray-200 dark:border-gray-600 overflow-hidden mt-4 mb-4"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -143,7 +142,7 @@ export default function TrackDetailPage({ track, onClose, onPlay }: TrackDetailP
         </div>
 
         {/* Scrollable Content */}
-        <div className="overflow-y-auto max-h-[calc(95vh-8rem)] sm:max-h-[calc(90vh-8rem)]">
+        <div className="overflow-y-auto max-h-[calc(100vh-8rem)]">
           <div className="p-6">
           {/* Track Info Grid */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">


### PR DESCRIPTION
## Summary
- ensure track detail screen uses full-screen scrollable overlay with consistent dark backdrop
- redesign music player to reveal song titles and open track info
- refine navigation and list spacing for better mobile fit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68903aa3dd8483298b948ed9270555c5