### PR TITLE
Simplify track search and clean up player UI

### DIFF
--- a/src/app/[spreadsheetId]/page.tsx
+++ b/src/app/[spreadsheetId]/page.tsx
@@ -153,6 +153,7 @@ export default function SpreadsheetPage() {
       <Artist
         artist={data.artist}
         onPlayTrack={handlePlayTrack}
+        onTrackInfo={handleTrackInfo}
         docId={spreadsheetId}
         sourceUrl={`https://docs.google.com/spreadsheets/d/${spreadsheetId}`}
         sheetType={currentSheet}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -36,36 +36,22 @@ export async function GET(request: NextRequest) {
           return false;
         }
 
-        // Search in multiple fields
         const titleMatch = track.title?.main?.toLowerCase().includes(searchQuery) || false;
-        const rawNameMatch = track.rawName?.toLowerCase().includes(searchQuery) || false;
-        const alternateNamesMatch = track.title?.alternateNames?.some((name: string) => 
+        const alternateNamesMatch = track.title?.alternateNames?.some((name: string) =>
           name?.toLowerCase().includes(searchQuery)
         ) || false;
-        const featuresMatch = track.title?.features?.some((feature: string) => 
-          feature?.toLowerCase().includes(searchQuery)
-        ) || false;
-        const collaboratorsMatch = track.title?.collaborators?.some((collab: string) => 
-          collab?.toLowerCase().includes(searchQuery)
-        ) || false;
-        const producersMatch = track.title?.producers?.some((producer: string) => 
-          producer?.toLowerCase().includes(searchQuery)
-        ) || false;
-        const notesMatch = track.notes?.toLowerCase().includes(searchQuery) || false;
-        const eraMatch = track.era?.toLowerCase().includes(searchQuery) || false;
-        
-        return titleMatch || rawNameMatch || alternateNamesMatch || featuresMatch || 
-               collaboratorsMatch || producersMatch || notesMatch || eraMatch;
+
+        return titleMatch || alternateNamesMatch;
       });
 
-      // Return album only if it has matching tracks or if the album name matches
-      if (filteredTracks.length > 0 || album.name.toLowerCase().includes(searchQuery)) {
+      // Return album only if it has matching tracks
+      if (filteredTracks.length > 0) {
         return {
           ...album,
           tracks: filteredTracks
         };
       }
-      
+
       return null;
     }).filter((album: Album | null) => album !== null);
 

--- a/src/components/Artist.tsx
+++ b/src/components/Artist.tsx
@@ -10,12 +10,13 @@ import { SheetType } from './SheetNavigation';
 interface ArtistProps {
   artist: ArtistType;
   onPlayTrack?: (track: Track) => void;
+  onTrackInfo?: (track: Track) => void;
   docId?: string;
   sourceUrl?: string;
   sheetType?: SheetType;
 }
 
-export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetType }: ArtistProps) {
+export default function Artist({ artist, onPlayTrack, onTrackInfo, docId, sourceUrl, sheetType }: ArtistProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -32,10 +33,8 @@ export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetTyp
 
   // Handle track info/details
   const handleTrackInfo = useCallback((track: Track) => {
-    // This would typically open a track details modal
-    // For now, we'll just log the track info
-    console.log('Track info:', track);
-  }, []);
+    onTrackInfo?.(track);
+  }, [onTrackInfo]);
 
     // Debounce search query to improve performance
   useEffect(() => {
@@ -100,48 +99,23 @@ export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetTyp
 
         // Search in track title main name
         const titleMatch = track.title?.main?.toLowerCase().includes(query) || false;
-        
-        // Search in raw name
-        const rawNameMatch = track.rawName?.toLowerCase().includes(query) || false;
-        
+
         // Search in alternate names
-        const alternateNamesMatch = track.title?.alternateNames?.some(name => 
+        const alternateNamesMatch = track.title?.alternateNames?.some(name =>
           name?.toLowerCase().includes(query)
         ) || false;
-        
-        // Search in features
-        const featuresMatch = track.title?.features?.some(feature => 
-          feature?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in collaborators
-        const collaboratorsMatch = track.title?.collaborators?.some(collab => 
-          collab?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in producers
-        const producersMatch = track.title?.producers?.some(producer => 
-          producer?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in notes
-        const notesMatch = track.notes?.toLowerCase().includes(query) || false;
-        
-        // Search in era
-        const eraMatch = track.era?.toLowerCase().includes(query) || false;
-        
-        return titleMatch || rawNameMatch || alternateNamesMatch || featuresMatch || 
-               collaboratorsMatch || producersMatch || notesMatch || eraMatch;
+
+        return titleMatch || alternateNamesMatch;
       });
 
-      // Return album only if it has matching tracks or if the album name matches
-      if (filteredTracks.length > 0 || album.name.toLowerCase().includes(query)) {
+      // Return album only if it has matching tracks
+      if (filteredTracks.length > 0) {
         return {
           ...album,
           tracks: filteredTracks
         };
       }
-      
+
       return null;
     }).filter(album => album !== null);
   }, [artist.albums, debouncedSearchQuery, sheetType]);
@@ -164,38 +138,13 @@ export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetTyp
 
         // Search in track title main name
         const titleMatch = track.title?.main?.toLowerCase().includes(query) || false;
-        
-        // Search in raw name
-        const rawNameMatch = track.rawName?.toLowerCase().includes(query) || false;
-        
+
         // Search in alternate names
-        const alternateNamesMatch = track.title?.alternateNames?.some(name => 
+        const alternateNamesMatch = track.title?.alternateNames?.some(name =>
           name?.toLowerCase().includes(query)
         ) || false;
-        
-        // Search in features
-        const featuresMatch = track.title?.features?.some(feature => 
-          feature?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in collaborators
-        const collaboratorsMatch = track.title?.collaborators?.some(collab => 
-          collab?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in producers
-        const producersMatch = track.title?.producers?.some(producer => 
-          producer?.toLowerCase().includes(query)
-        ) || false;
-        
-        // Search in notes
-        const notesMatch = track.notes?.toLowerCase().includes(query) || false;
-        
-        // Search in era
-        const eraMatch = track.era?.toLowerCase().includes(query) || false;
-        
-        if (titleMatch || rawNameMatch || alternateNamesMatch || featuresMatch || 
-            collaboratorsMatch || producersMatch || notesMatch || eraMatch) {
+
+        if (titleMatch || alternateNamesMatch) {
           allTracks.push({
             ...track,
             albumName: album.name
@@ -305,7 +254,7 @@ export default function Artist({ artist, onPlayTrack, docId, sourceUrl, sheetTyp
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search for tracks by title, alternate names, or notes... (Ctrl+K)"
+            placeholder="Search for tracks by title or alternate names... (Ctrl+K)"
             className="block w-full pl-10 pr-12 py-2.5 sm:py-3 border border-gray-300 dark:border-gray-600 rounded-xl leading-5 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 shadow-sm transition-all duration-200"
           />
           {searchQuery && (

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { Track } from '@/types';
-import MetadataModal from './MetadataModal';
 
 interface MusicPlayerProps {
   track: Track | null;
@@ -18,7 +17,6 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
   const [volume, setVolume] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isMetadataModalOpen, setIsMetadataModalOpen] = useState(false);
   const audioRef = useRef<HTMLAudioElement>(null);
 
 
@@ -66,7 +64,6 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
   const audioUrl = playable && (playable.type === 'audio' || playable.type === 'pillowcase' || playable.type === 'froste') ? playable.url : null;
   const isSoundCloudLink = playable?.type === 'soundcloud';
   const isYouTubeLink = playable?.type === 'youtube';
-  const isPillowcase = playable?.type === 'pillowcase';
 
   // For YouTube: convert to audio stream via API
   const [youtubeAudioUrl, setYoutubeAudioUrl] = useState<string | null>(null);
@@ -114,6 +111,7 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
         // Auto-play when track loads
         audio.play().catch(() => {
           setError('Failed to auto-play audio');
+          setTimeout(() => setError(null), 3000);
         });
       };
       const handleError = () => {
@@ -146,8 +144,10 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
       // Auto-play
       audioRef.current.play().then(() => {
         setIsPlaying(true);
+        setError(null);
       }).catch(() => {
         setError('Failed to auto-play audio');
+        setTimeout(() => setError(null), 3000);
       });
     }
   }, [track, audioUrl]);
@@ -160,11 +160,13 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
 
   const togglePlayPause = () => {
     if (audioRef.current) {
+      setError(null);
       if (isPlaying) {
         audioRef.current.pause();
       } else {
         audioRef.current.play().catch(() => {
           setError('Failed to play audio');
+          setTimeout(() => setError(null), 3000);
         });
       }
       setIsPlaying(!isPlaying);
@@ -227,22 +229,6 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
                 >
                   <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 18a6 6 0 100-12 6 6 0 000 12z" />
-                  </svg>
-                </button>
-              )}
-              {isPillowcase && playable?.id && (
-                <button
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsMetadataModalOpen(true);
-                  }}
-                  className="p-1.5 sm:p-2.5 text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400 transition-colors rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 active:scale-95 flex-shrink-0"
-                  title="View metadata"
-                  aria-label="View track metadata"
-                >
-                  <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </button>
               )}
@@ -387,7 +373,10 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
           <audio
             ref={audioRef}
             src={audioUrl}
-            onPlay={() => setIsPlaying(true)}
+            onPlay={() => {
+              setIsPlaying(true);
+              setError(null);
+            }}
             onPause={() => setIsPlaying(false)}
             onEnded={() => setIsPlaying(false)}
           />
@@ -396,22 +385,15 @@ export default function MusicPlayer({ track, isVisible, onClose, onInfo }: Music
           <audio
             ref={audioRef}
             src={youtubeAudioUrl}
-            onPlay={() => setIsPlaying(true)}
+            onPlay={() => {
+              setIsPlaying(true);
+              setError(null);
+            }}
             onPause={() => setIsPlaying(false)}
             onEnded={() => setIsPlaying(false)}
           />
         )}
       </div>
-
-      {/* Metadata Modal */}
-      {isPillowcase && playable?.id && (
-        <MetadataModal
-          isOpen={isMetadataModalOpen}
-          onClose={() => setIsMetadataModalOpen(false)}
-          metadataUrl={`https://api.pillows.su/api/metadata/${playable.id}.txt`}
-          trackName={track?.title?.main || track?.rawName || 'Unknown Track'}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- limit search to track titles and alternate names for faster results
- wire search info buttons to open track detail modals
- remove metadata button from music player and clear auto-play errors automatically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689047fff4588329b0a77218e5ca3233